### PR TITLE
fix enclosure blink

### DIFF
--- a/skill_randomness/__init__.py
+++ b/skill_randomness/__init__.py
@@ -28,7 +28,7 @@ class RandomnessSkill(OVOSSkill):
             result = Die(first_choice, second_choice).sample()
         self.speak_dialog("choice-result", data={"choice": result})
         self.gui.show_text(result)
-        self.enclosure.eyes_blink(2)
+        self.enclosure.eyes_blink("b")
         self.enclosure.mouth_text(result)
 
     @intent_handler("pick-a-number.intent")


### PR DESCRIPTION
skill is mixing these 2 apis

```python
    def system_blink(self, times):
        """The 'eyes' should blink the given number of times.
        Args:
            times (int): number of times to blink
        """
        source_message = self._get_source_message()
        self.bus.emit(source_message.forward("enclosure.system.blink",
                                             {'times': times}))
 
    def eyes_blink(self, side):
        """Make the eyes blink
        Args:
            side (str): 'r', 'l', or 'b' for 'right', 'left' or 'both'
        """
        source_message = self._get_source_message()
        self.bus.emit(source_message.forward("enclosure.eyes.blink",
                                             {'side': side}))
```

causing

```
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]: 2024-04-24 20:14:35.323 - HiveMind-voice-sat - ovos_bus_client.client.client:on_error:120 - ERROR - === TypeError('can only concatenate str (not "int") to str') ===
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]: Traceback (most recent call last):
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/websocket/_app.py", line 660, in _callback
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     callback(self, *args)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/hivemind_bus_client/client.py", line 243, in on_message
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     self._handle_hive_protocol(HiveMessage(**message))
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/hivemind_bus_client/client.py", line 248, in _handle_hive_protocol
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     self.internal_bus.emit(message.payload)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_utils/fakebus.py", line 50, in emit
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     self.ee.emit(message.msg_type, message)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/pyee/_base.py", line 115, in emit
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     handled = self._call_handlers(event, args, kwargs)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/pyee/_base.py", line 98, in _call_handlers
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     self._emit_run(f, args, kwargs)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/pyee/_base.py", line 83, in _emit_run
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     f(*args, **kwargs)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_PHAL_plugin_mk1/__init__.py", line 296, in on_eyes_blink
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:     self.writer.write("eyes.blink=" + side)
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]:                       ~~~~~~~~~~~~~~^~~~~~
Apr 24 20:14:35 mark1 hivemind-voice-sat[2934]: TypeError: can only concatenate str (not "int") to str
```